### PR TITLE
feat: load config from current path

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,10 +188,15 @@ LiveServer.start = function(options) {
 	middleware.map(function(mw) {
 		if (typeof mw === "string") {
 			var ext = path.extname(mw).toLocaleLowerCase();
-			if (ext !== ".js") {
-				mw = require(path.join(__dirname, "middleware", mw + ".js"));
+			if (mw.startsWith("./")) {
+				if (ext !== ".js") mw += ".js";
+				mw = require(path.join(process.cwd(), mw));
 			} else {
-				mw = require(mw);
+				if (ext !== ".js") {
+					mw = require(path.join(__dirname, "middleware", mw));
+				} else {
+					mw = require(mw);
+				}
 			}
 		}
 		app.use(mw);

--- a/live-server.js
+++ b/live-server.js
@@ -25,9 +25,15 @@ if (fs.existsSync(configPath)) {
 var projConfigPath = path.join(process.cwd(), '.alive-server.json');
 if (fs.existsSync(projConfigPath)) {
 	var projConfig = fs.readFileSync(projConfigPath, 'utf8');
-	assign(opts, JSON.parse(projConfigPath));
+	assign(opts, JSON.parse(projConfig));
 }
 if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
+if (opts.ignore && typeof (opts.ignore) === 'string') {
+	opts.ignore = opts.ignore.split(',');
+}
+if (opts.watch && typeof (opts.watch) === 'string') {
+	opts.watch = opts.watch.split(',');
+}
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
 	var arg = process.argv[i];

--- a/live-server.js
+++ b/live-server.js
@@ -15,13 +15,19 @@ var opts = {
 	logLevel: 2,
 };
 
+
 var homeDir = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
 var configPath = path.join(homeDir, '.alive-server.json');
 if (fs.existsSync(configPath)) {
 	var userConfig = fs.readFileSync(configPath, 'utf8');
 	assign(opts, JSON.parse(userConfig));
-	if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 }
+var projConfigPath = path.join(process.cwd(), '.alive-server.json');
+if (fs.existsSync(projConfigPath)) {
+	var projConfig = fs.readFileSync(projConfigPath, 'utf8');
+	assign(opts, JSON.parse(projConfigPath));
+}
+if (opts.ignorePattern) opts.ignorePattern = new RegExp(opts.ignorePattern);
 
 for (var i = process.argv.length - 1; i >= 2; --i) {
 	var arg = process.argv[i];


### PR DESCRIPTION
This PR doing these two things:

* Let `.alive-server.json` could be read also from the path where the command running, just like `serve` does.
* Convert string to array for `ignore` and `watch` field when reading from config file.
* Support load middleware scripts from current path.