### PR TITLE
Rename instances of live-server to alive-server

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-###### Before submitting an issue, please, see https://github.com/tapio/live-server#troubleshooting
+###### Before submitting an issue, please, see https://github.com/tapio/alive-server#troubleshooting
 
 ## Issue description
 
 ## Software details
 
-* Command line used for launching `live-server`:
+* Command line used for launching `alive-server`:
 * OS:
 * Browser (if browser related):
 * Node.js version:
-* `live-server` version:
+* `alive-server` version:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Live Server
 ===========
 
-A fork of tapio/live-server but Alive , PR's are welcome and reviewed within a week
+A fork of [tapio/live-server](https://github.com/tapio/live-server) but Alive, PR's are welcome and reviewed within a week
 
 ----------
 
@@ -72,14 +72,14 @@ Command line parameters:
 
 Default options:
 
-If a file `~/.alive-server.json` exists it will be loaded and used as default options for live-server on the command line. See "Usage from node" for option names.
+If a file `~/.alive-server.json` exists it will be loaded and used as default options for alive-server on the command line. See "Usage from node" for option names.
 
 
 Usage from node
 ---------------
 
 ```javascript
-var liveServer = require("alive-server");
+var aliveServer = require("alive-server");
 
 var params = {
 	port: 8181, // Set the server port. Defaults to 8080.
@@ -95,7 +95,7 @@ var params = {
 	mimetypes: { 'application/wasm': ['.wasm'] }, // Set extended MIME types,
 	index: 'index.html,index.js' // By default send supports "index.html" files, to disable this set false or to supply a new index pass a string or an array in preferred order 
 };
-liveServer.start(params);
+aliveServer.start(params);
 ```
 
 HTTPS

--- a/alive-server.js
+++ b/alive-server.js
@@ -171,7 +171,7 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 		process.argv.splice(i, 1);
 	}
 	else if (arg === "--help" || arg === "-h") {
-		console.log('Usage: live-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
+		console.log('Usage: alive-server [-v|--version] [-h|--help] [-q|--quiet] [--port=PORT] [--host=HOST] [--open=PATH] [--no-browser] [--browser=BROWSER] [--ignore=PATH] [--ignorePattern=RGXP] [--no-css-inject] [--entry-file=PATH] [--spa] [--mount=ROUTE:PATH] [--wait=MILLISECONDS] [--htpasswd=PATH] [--cors] [--https=PATH] [--https-module=MODULE_NAME] [--proxy=PATH] [PATH]');
 		process.exit();
 	}
 	else if (arg === "--test") {

--- a/injected.html
+++ b/injected.html
@@ -1,4 +1,4 @@
-<!-- Code injected by live-server -->
+<!-- Code injected by alive-server -->
 <script type="text/javascript">
 	// <![CDATA[  <-- For SVG support
 	if ('WebSocket' in window) {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "supertest": "^6.3.3"
   },
   "scripts": {
-    "lint": "eslint live-server.js index.js",
-    "hint": "jshint live-server.js index.js",
+    "lint": "eslint alive-server.js index.js",
+    "hint": "jshint alive-server.js index.js",
     "test": "mocha test --exit && npm run lint"
   },
   "bin": {
-    "alive-server": "./live-server.js"
+    "alive-server": "./alive-server.js"
   },
   "repository": {
     "type": "git",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var path = require('path');
 var exec = require('child_process').execFile;
-var cmd = path.join(__dirname, "..", "live-server.js");
+var cmd = path.join(__dirname, "..", "alive-server.js");
 var opts = {
 	timeout: 2000,
 	maxBuffer: 1024
@@ -17,14 +17,14 @@ describe('command line usage', function() {
 	it('--version', function(done) {
 		exec_test([ "--version" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("live-server") === 0, "version not found");
+			assert(stdout.indexOf("alive-server") === 0, "version not found");
 			done();
 		});
 	});
 	it('--help', function(done) {
 		exec_test([ "--help" ], function(error, stdout, stdin) {
 			assert(!error, error);
-			assert(stdout.indexOf("Usage: live-server") === 0, "usage not found");
+			assert(stdout.indexOf("Usage: alive-server") === 0, "usage not found");
 			done();
 		});
 	});


### PR DESCRIPTION
Happens to fix the failing test (where --version outputs live-server instead of alive-server)

Also changed minor things in README (add link, remove random space)