### PR TITLE
Handle edge cases in open path

### DIFF
--- a/alive-server.js
+++ b/alive-server.js
@@ -51,9 +51,6 @@ for (var i = process.argv.length - 1; i >= 2; --i) {
 	}
 	else if (arg.indexOf("--open=") > -1) {
 		var open = arg.substring(7);
-		if (open.indexOf('/') !== 0) {
-			open = '/' + open;
-		}
 		switch (typeof opts.open) {
 			case "boolean":
 				opts.open = open;

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ LiveServer.start = function(options) {
 	var watchPaths = options.watch || [root];
 	LiveServer.logLevel = options.logLevel === undefined ? 2 : options.logLevel;
 	var openPath = (options.open === undefined || options.open === true) ?
-		"" : ((options.open === null || options.open === false) ? null : options.open);
+		"/" : ((options.open === null || options.open === false) ? null : options.open);
 	if (options.noBrowser) openPath = null; // Backwards compatibility with 0.7.0
 	var file = options.file;
 	var staticServerHandler = staticServer(root);
@@ -312,14 +312,21 @@ LiveServer.start = function(options) {
 		}
 
 		// Launch browser
-		if (openPath !== null)
-			if (typeof openPath === "object") {
-				openPath.forEach(function(p) {
-					open(openURL + p, {app: browser});
-				});
-			} else {
-				open(openURL + openPath, {app: browser});
-			}
+		if (openPath !== null) {
+			if (openPath.forEach === undefined)
+				openPath = [ openPath ];
+			openPath.forEach(function(p) {
+				if (p.startsWith("./"))
+					p = p.slice(1);
+				else if (p[0] !== "/")
+					p = "/" + p;
+				if (p.startsWith("/../")) {
+					console.warn(`Open path cannot be in parent directories: ${p}`.yellow);
+					return;
+				}
+				open(openURL + p, { app: browser });
+			});
+		}
 	});
 
 	// Setup server to listen at port


### PR DESCRIPTION
In both cli and code:
* Allow relative paths (eg: `./example/`, `example/`)
* Warn for parent paths (eg: `../example`, `/../example`, `./../example`)